### PR TITLE
Use [Jj] regex in auto-mode-alist entry

### DIFF
--- a/just-mode.el
+++ b/just-mode.el
@@ -161,8 +161,8 @@ Argument N number of untabs to perform"
 (provide 'just-mode)
 
 ;;;###autoload
-(add-to-list 'auto-mode-alist '("/justfile\\'" . just-mode))
+(add-to-list 'auto-mode-alist '("/[Jj]ustfile\\'" . just-mode))
 ;;;###autoload
-(add-to-list 'auto-mode-alist '("\\.just\\(file\\)?\\'" . just-mode))
+(add-to-list 'auto-mode-alist '("\\.[Jj]ust\\(file\\)?\\'" . just-mode))
 
 ;;; just-mode.el ends here


### PR DESCRIPTION
Hey, just noticed that there are quite a few projects that use a justfile with capital first letter: https://github.com/search?o=desc&q=filename%3Ajustfile&s=indexed&type=Code