### PR TITLE
Task source editing functionality (similar to what's in `org-src`)

### DIFF
--- a/just-mode.el
+++ b/just-mode.el
@@ -294,13 +294,14 @@ Returns (task-name body-start body-end) or nil if not in a task."
         (setq task-name (match-string 1))
         (setq body-start (line-beginning-position 2))
 
-        ;; Find the end of this task by looking for the next task
+        ;; Find the next line with no indentation (column 0)
         (forward-line 1)
         (while (and (not (eobp))
-                    (not (looking-at task-regexp)))
+                    (not (and (not (looking-at "^\\s-*$"))    ; not empty line
+                              (looking-at "^[^ \\t]"))))     ; starts at column 0
           (forward-line 1))
 
-        ;; Go back to find the last non-empty line before the next task
+        ;; Go back to find the last non-empty line before the unindented line
         (forward-line -1)
         (while (and (> (point) body-start)
                     (looking-at "^\\s-*$"))

--- a/just-mode.el
+++ b/just-mode.el
@@ -368,6 +368,13 @@ If content starts with shebang, use normal-mode, otherwise sh-mode."
       (insert clean-content)
       (goto-char (point-min))
 
+      ;; Ensure buffer ends with newline
+      (goto-char (point-max))
+      (unless (and (> (point-max) (point-min))
+                   (= (char-before) ?\n))
+        (insert "\n"))
+      (goto-char (point-min))
+
       ;; Detect and set appropriate mode
       (funcall (just--detect-language-mode clean-content))
 

--- a/just-mode.el
+++ b/just-mode.el
@@ -242,7 +242,7 @@ Argument N number of untabs to perform"
   (setq-local indent-line-function 'just-indent-line)
   (local-set-key (kbd "DEL") #'just-backspace-whitespace-to-tab-stop)
   (local-set-key (kbd "<backtab>") #'just-untab-region)
-  (local-set-key (kbd "C-c C-'") #'just-src-edit))
+  (local-set-key (kbd "C-c '") #'just-src-edit))
 
 ;;; Recipe body editing
 
@@ -391,14 +391,14 @@ If content starts with shebang, use `normal-mode', otherwise `sh-mode'."
 
       ;; Set up key bindings
       (local-set-key (kbd "C-x C-s") #'just-src-edit-save)
-      (local-set-key (kbd "C-c C-'") #'just-src-edit-sync-and-exit)
+      (local-set-key (kbd "C-c '") #'just-src-edit-sync-and-exit)
       (local-set-key (kbd "C-c C-k") #'just-src-edit-abort)
 
       ;; Set up save hook
       (add-hook 'write-contents-functions #'just-src-edit-save nil t)
 
       ;; Show helpful message
-      (message "Edit recipe '%s'. C-c C-' to sync and exit, C-x C-s to save, C-c C-k to abort" recipe-name))))
+      (message "Edit recipe '%s'. C-c ' to sync and exit, C-x C-s to save, C-c C-k to abort" recipe-name))))
 
 (defun just-src-edit-save ()
   "Save the edited recipe back to the original buffer and file."

--- a/just-mode.el
+++ b/just-mode.el
@@ -271,18 +271,18 @@ Returns (recipe-name body-start body-end) or nil if not in a recipe."
       ;; Find the task we're currently in using the same regex as imenu
       ;; Go back to find a task line
       (while (and (not (bobp))
-                  (not (looking-at "^\\(?:alias +\\)?@?\\([A-Z_a-z][0-9A-Z_a-z-]*\\).*:[^=]")))
+                  (not (looking-at "^@?\\([A-Z_a-z][0-9A-Z_a-z-]*\\).*:[^=]")))
         (forward-line -1))
 
       ;; If we found a task line
-      (when (looking-at "^\\(?:alias +\\)?@?\\([A-Z_a-z][0-9A-Z_a-z-]*\\).*:[^=]")
+      (when (looking-at "^@?\\([A-Z_a-z][0-9A-Z_a-z-]*\\).*:[^=]")
         (setq task-name (match-string 1))
         (setq body-start (line-beginning-position 2))
 
         ;; Find the end of this task by looking for the next task
         (forward-line 1)
         (while (and (not (eobp))
-                    (not (looking-at "^\\(?:alias +\\)?@?\\([A-Z_a-z][0-9A-Z_a-z-]*\\).*:[^=]")))
+                    (not (looking-at "^@?\\([A-Z_a-z][0-9A-Z_a-z-]*\\).*:[^=]")))
           (forward-line 1))
 
         ;; Go back to find the last non-empty line before the next task
@@ -381,27 +381,27 @@ If content starts with shebang, use normal-mode, otherwise sh-mode."
       (setq just-edit--recipe-name recipe-name)
 
       ;; Set up key bindings
-      (local-set-key (kbd "C-x C-s") #'just-edit-save-and-exit)
-      (local-set-key (kbd "C-c C-'") #'just-edit-preview)
+      (local-set-key (kbd "C-x C-s") #'just-edit-save)
+      (local-set-key (kbd "C-c C-'") #'just-edit-sync-and-exit)
       (local-set-key (kbd "C-c C-k") #'just-edit-abort)
 
       ;; Set up save hook
-      (add-hook 'write-contents-functions #'just-edit-save-and-exit nil t)
+      (add-hook 'write-contents-functions #'just-edit-save nil t)
 
       ;; Show helpful message
-      (message "Edit recipe '%s'. C-c C-' to preview, C-x C-s to save, C-c C-k to abort" recipe-name))))
+      (message "Edit recipe '%s'. C-c C-' to sync and exit, C-x C-s to save, C-c C-k to abort" recipe-name))))
 
-(defun just-edit-save-and-exit ()
-  "Save the edited recipe back to the original buffer and exit."
+(defun just-edit-save ()
+  "Save the edited recipe back to the original buffer and file."
   (interactive)
-  (just--sync-to-original t)
-  (quit-window t))
+  (just--sync-to-original t))
 
-(defun just-edit-preview ()
-  "Preview changes by syncing to original buffer without saving."
+(defun just-edit-sync-and-exit ()
+  "Sync changes to original buffer and exit edit buffer."
   (interactive)
   (just--sync-to-original nil)
-  (message "Previewed changes in original buffer"))
+  (quit-window t)
+  (message "Synced changes to original buffer"))
 
 (defun just-edit-abort ()
   "Abort editing without saving changes."

--- a/just-mode.el
+++ b/just-mode.el
@@ -246,6 +246,20 @@ Argument N number of untabs to perform"
 
 ;;; Recipe body editing
 
+(defvar just-src-edit-mode-map
+  (let ((map (make-sparse-keymap)))
+    (define-key map (kbd "C-x C-s") #'just-src-edit-save)
+    (define-key map (kbd "C-c '") #'just-src-edit-sync-and-exit)
+    (define-key map (kbd "C-c C-k") #'just-src-edit-abort)
+    map)
+  "Keymap for `just-src-edit-mode'.")
+
+(define-minor-mode just-src-edit-mode
+  "Minor mode for editing Just recipe bodies."
+  :init-value nil
+  :lighter " Just-Edit"
+  :keymap just-src-edit-mode-map)
+
 (defvar-local just-src-edit--original-buffer nil)
 (put 'just-src-edit--original-buffer 'permanent-local t)
 
@@ -389,10 +403,8 @@ If content starts with shebang, use `normal-mode', otherwise `sh-mode'."
       (setq just-src-edit--indentation indentation)
       (setq just-src-edit--recipe-name recipe-name)
 
-      ;; Set up key bindings
-      (local-set-key (kbd "C-x C-s") #'just-src-edit-save)
-      (local-set-key (kbd "C-c '") #'just-src-edit-sync-and-exit)
-      (local-set-key (kbd "C-c C-k") #'just-src-edit-abort)
+      ;; Enable the minor mode for keybindings
+      (just-src-edit-mode 1)
 
       ;; Set up save hook
       (add-hook 'write-contents-functions #'just-src-edit-save nil t)

--- a/just-mode.el
+++ b/just-mode.el
@@ -163,7 +163,7 @@ Argument N number of untabs to perform"
   (let ((exit-code (call-process just-executable nil nil nil "--unstable" "--fmt")))
     (if (eq exit-code 0)
         (revert-buffer :ignore-auto :noconfirm)
-      (message "Formatted")
+        (message "Formatted")
       (message "Format failed with exit code %s" exit-code))))
 
 ;; from https://www.emacswiki.org/emacs/BackspaceWhitespaceToTabStop

--- a/just-mode.el
+++ b/just-mode.el
@@ -331,7 +331,7 @@ Returns (recipe-name body-start body-end) or nil if not in a recipe."
 
 (defun just-src-edit--remove-indentation (content indentation)
   "Remove INDENTATION spaces from each line of CONTENT."
-  (let ((lines (string-lines content)))
+  (let ((lines (split-string content "\n")))
     (mapconcat
      (lambda (line)
        (if (string-match-p "^\\s-*$" line)
@@ -345,7 +345,7 @@ Returns (recipe-name body-start body-end) or nil if not in a recipe."
 
 (defun just-src-edit--add-indentation (content indentation)
   "Add INDENTATION spaces to each line of CONTENT."
-  (let ((lines (string-lines content))
+  (let ((lines (split-string content "\n"))
         (indent-str (make-string indentation ?\s)))
     (mapconcat
      (lambda (line)

--- a/just-mode.el
+++ b/just-mode.el
@@ -355,13 +355,6 @@ Returns (recipe-name body-start body-end) or nil if not in a recipe."
      lines
      "\n")))
 
-(defun just-src-edit--detect-language-mode (content)
-  "Detect the appropriate major mode for CONTENT.
-If content starts with shebang, use `normal-mode', otherwise `sh-mode'."
-  (if (string-match "^#!" content)
-      'normal-mode
-    'sh-mode))
-
 (defun just-src-edit ()
   "Edit the recipe body at point in a dedicated buffer."
   (interactive)
@@ -393,7 +386,9 @@ If content starts with shebang, use `normal-mode', otherwise `sh-mode'."
       (goto-char (point-min))
 
       ;; Detect and set appropriate mode
-      (funcall (just-src-edit--detect-language-mode clean-content))
+      (if (string-match "^#!" clean-content)
+          (normal-mode)
+        (sh-mode))
 
       ;; Set up buffer-local variables
       (setq just-src-edit--original-buffer original-buffer)

--- a/just-mode.el
+++ b/just-mode.el
@@ -424,7 +424,7 @@ If SAVE-FILE is non-nil, also save the original buffer."
                (buffer-live-p just-src-edit--original-buffer))
     (error "Original buffer no longer exists"))
 
-  (let ((content (buffer-string))
+  (let ((content (string-trim-right (buffer-string) "\n"))
         (original-buf just-src-edit--original-buffer)
         (beg just-src-edit--beg-marker)
         (end just-src-edit--end-marker)

--- a/just-mode.el
+++ b/just-mode.el
@@ -410,7 +410,15 @@ If content starts with shebang, use `normal-mode', otherwise `sh-mode'."
       (add-hook 'write-contents-functions #'just-src-edit-save nil t)
 
       ;; Show helpful message
-      (message "Edit recipe '%s'. C-c ' to sync and exit, C-x C-s to save, C-c C-k to abort" recipe-name))))
+      (message "Edit recipe '%s'. %s" recipe-name (just-src-edit--describe-bindings)))))
+
+(defun just-src-edit--describe-bindings ()
+  "Return a string describing the current key bindings for just-src-edit-mode."
+  (let ((sync-key (substitute-command-keys "\\[just-src-edit-sync-and-exit]"))
+        (save-key (substitute-command-keys "\\[just-src-edit-save]"))
+        (abort-key (substitute-command-keys "\\[just-src-edit-abort]")))
+    (format "%s to sync and exit, %s to save, %s to abort"
+            sync-key save-key abort-key)))
 
 (defun just-src-edit-save ()
   "Save the edited recipe back to the original buffer and file."

--- a/just-mode.el
+++ b/just-mode.el
@@ -297,8 +297,8 @@ Returns (task-name body-start body-end) or nil if not in a task."
         ;; Find the next line with no indentation (column 0)
         (forward-line 1)
         (while (and (not (eobp))
-                    (not (and (not (looking-at "^\\s-*$"))    ; not empty line
-                              (looking-at "^[^ \\t]"))))     ; starts at column 0
+                    (not (and (not (looking-at "^\\s-*$")) ; not empty line
+                              (looking-at "^[^ \t\n]"))))  ; starts at column 0
           (forward-line 1))
 
         ;; Go back to find the last non-empty line before the unindented line
@@ -438,7 +438,7 @@ If SAVE-FILE is non-nil, also save the original buffer."
                (buffer-live-p just-src-edit--original-buffer))
     (error "Original buffer no longer exists"))
 
-  (let ((content (string-trim-right (buffer-string) "\n"))
+  (let ((content (string-trim-right (buffer-string) "\n+"))
         (original-buf just-src-edit--original-buffer)
         (beg just-src-edit--beg-marker)
         (end just-src-edit--end-marker)

--- a/just-mode.el
+++ b/just-mode.el
@@ -340,8 +340,8 @@ Returns (recipe-name body-start body-end) or nil if not in a recipe."
 
 (defun just-src-edit--detect-language-mode (content)
   "Detect the appropriate major mode for CONTENT.
-If content starts with shebang, use normal-mode, otherwise sh-mode."
-  (if (string-match "^\\s-*#!" content)
+If content starts with shebang, use `normal-mode', otherwise `sh-mode'."
+  (if (string-match "^#!" content)
       'normal-mode
     'sh-mode))
 

--- a/just-mode.el
+++ b/just-mode.el
@@ -316,27 +316,29 @@ Returns (recipe-name body-start body-end) or nil if not in a recipe."
 
 (defun just-src-edit--remove-indentation (content indentation)
   "Remove INDENTATION spaces from each line of CONTENT."
-  (with-temp-buffer
-    (insert content)
-    (goto-char (point-min))
-    (while (not (eobp))
-      (unless (looking-at "^\\s-*$")  ; don't modify empty lines
-        (when (>= (current-indentation) indentation)
-          (delete-char indentation)))
-      (forward-line 1))
-    (buffer-string)))
+  (let ((lines (string-lines content)))
+    (mapconcat
+     (lambda (line)
+       (if (string-match-p "^\\s-*$" line)
+           line
+         (if (and (>= (length line) indentation)
+                  (string-match-p (concat "^ \\{" (number-to-string indentation) "\\}") line))
+             (substring line indentation)
+           line)))
+     lines
+     "\n")))
 
 (defun just-src-edit--add-indentation (content indentation)
   "Add INDENTATION spaces to each line of CONTENT."
-  (with-temp-buffer
-    (insert content)
-    (goto-char (point-min))
-    (let ((indent-str (make-string indentation ?\s)))
-      (while (not (eobp))
-        (unless (looking-at "^\\s-*$")  ; don't modify empty lines
-          (insert indent-str))
-        (forward-line 1)))
-    (buffer-string)))
+  (let ((lines (string-lines content))
+        (indent-str (make-string indentation ?\s)))
+    (mapconcat
+     (lambda (line)
+       (if (string-match-p "^\\s-*$" line)
+           line
+         (concat indent-str line)))
+     lines
+     "\n")))
 
 (defun just-src-edit--detect-language-mode (content)
   "Detect the appropriate major mode for CONTENT.

--- a/just-mode.el
+++ b/just-mode.el
@@ -455,7 +455,6 @@ If SAVE-FILE is non-nil, also save the original buffer."
         (save-buffer)))
 
     (set-buffer-modified-p nil)))
-
 
 (provide 'just-mode)
 

--- a/just-mode.el
+++ b/just-mode.el
@@ -244,7 +244,7 @@ Argument N number of untabs to perform"
   (local-set-key (kbd "<backtab>") #'just-untab-region)
   (local-set-key (kbd "C-c '") #'just-src-edit))
 
-;;; Recipe body editing
+;;; Task body editing
 
 (defvar just-src-edit-mode-map
   (let ((map (make-sparse-keymap)))
@@ -255,7 +255,7 @@ Argument N number of untabs to perform"
   "Keymap for `just-src-edit-mode'.")
 
 (define-minor-mode just-src-edit-mode
-  "Minor mode for editing Just recipe bodies."
+  "Minor mode for editing Just task bodies."
   :init-value nil
   :lighter " Just-Edit"
   :keymap just-src-edit-mode-map)
@@ -272,12 +272,12 @@ Argument N number of untabs to perform"
 (defvar-local just-src-edit--indentation nil)
 (put 'just-src-edit--indentation 'permanent-local t)
 
-(defvar-local just-src-edit--recipe-name nil)
-(put 'just-src-edit--recipe-name 'permanent-local t)
+(defvar-local just-src-edit--task-name nil)
+(put 'just-src-edit--task-name 'permanent-local t)
 
-(defun just-src-edit--find-recipe-bounds ()
-  "Find the bounds of the recipe at point.
-Returns (recipe-name body-start body-end) or nil if not in a recipe."
+(defun just-src-edit--find-task-bounds ()
+  "Find the bounds of the task at point.
+Returns (task-name body-start body-end) or nil if not in a task."
   (save-excursion
     (let ((start-pos (point))
           (task-regexp "^@?\\([A-Z_a-z][0-9A-Z_a-z-]*\\).*:[^=]")
@@ -319,7 +319,7 @@ Returns (recipe-name body-start body-end) or nil if not in a recipe."
           (list task-name body-start body-end))))))
 
 (defun just-src-edit--calculate-indentation (start end)
-  "Calculate the common indentation for recipe body between START and END."
+  "Calculate the common indentation for task body between START and END."
   (save-excursion
     (goto-char start)
     (let ((min-indent most-positive-fixnum))
@@ -356,20 +356,20 @@ Returns (recipe-name body-start body-end) or nil if not in a recipe."
      "\n")))
 
 (defun just-src-edit ()
-  "Edit the recipe body at point in a dedicated buffer."
+  "Edit the task body at point in a dedicated buffer."
   (interactive)
-  (let ((recipe-info (just-src-edit--find-recipe-bounds)))
-    (unless recipe-info
-      (user-error "Not in a recipe body"))
+  (let ((task-info (just-src-edit--find-task-bounds)))
+    (unless task-info
+      (user-error "Not in a task body"))
 
-    (let* ((recipe-name (nth 0 recipe-info))
-           (body-start (nth 1 recipe-info))
-           (body-end (nth 2 recipe-info))
+    (let* ((task-name (nth 0 task-info))
+           (body-start (nth 1 task-info))
+           (body-end (nth 2 task-info))
            (original-buffer (current-buffer))
            (indentation (just-src-edit--calculate-indentation body-start body-end))
            (content (buffer-substring-no-properties body-start body-end))
            (clean-content (just-src-edit--remove-indentation content indentation))
-           (edit-buffer (generate-new-buffer (format "*Just Recipe: %s*" recipe-name))))
+           (edit-buffer (generate-new-buffer (format "*Just Task: %s*" task-name))))
 
       ;; Switch to edit buffer
       (pop-to-buffer edit-buffer)
@@ -397,13 +397,13 @@ Returns (recipe-name body-start body-end) or nil if not in a recipe."
       (setq just-src-edit--end-marker (with-current-buffer original-buffer
                                         (copy-marker body-end t)))
       (setq just-src-edit--indentation indentation)
-      (setq just-src-edit--recipe-name recipe-name)
+      (setq just-src-edit--task-name task-name)
 
       ;; Enable the minor mode for keybindings
       (just-src-edit-mode 1)
 
       ;; Show helpful message
-      (message "Edit recipe '%s'. %s" recipe-name (just-src-edit--describe-bindings)))))
+      (message "Edit task '%s'. %s" task-name (just-src-edit--describe-bindings)))))
 
 (defun just-src-edit--describe-bindings ()
   "Return a string describing the current key bindings for just-src-edit-mode."
@@ -414,7 +414,7 @@ Returns (recipe-name body-start body-end) or nil if not in a recipe."
             sync-key save-key abort-key)))
 
 (defun just-src-edit-save ()
-  "Save the edited recipe back to the original buffer and file."
+  "Save the edited task back to the original buffer and file."
   (interactive)
   (just-src-edit--sync-to-original t))
 

--- a/just-mode.el
+++ b/just-mode.el
@@ -163,7 +163,7 @@ Argument N number of untabs to perform"
   (let ((exit-code (call-process just-executable nil nil nil "--unstable" "--fmt")))
     (if (eq exit-code 0)
         (revert-buffer :ignore-auto :noconfirm)
-        (message "Formatted")
+      (message "Formatted")
       (message "Format failed with exit code %s" exit-code))))
 
 ;; from https://www.emacswiki.org/emacs/BackspaceWhitespaceToTabStop
@@ -402,9 +402,6 @@ Returns (recipe-name body-start body-end) or nil if not in a recipe."
       ;; Enable the minor mode for keybindings
       (just-src-edit-mode 1)
 
-      ;; Set up save hook
-      (add-hook 'write-contents-functions #'just-src-edit-save nil t)
-
       ;; Show helpful message
       (message "Edit recipe '%s'. %s" recipe-name (just-src-edit--describe-bindings)))))
 
@@ -457,8 +454,7 @@ If SAVE-FILE is non-nil, also save the original buffer."
       (when save-file
         (save-buffer)))
 
-    (set-buffer-modified-p nil)
-    t))
+    (set-buffer-modified-p nil)))
 
 
 (provide 'just-mode)

--- a/just-mode.el
+++ b/just-mode.el
@@ -280,23 +280,24 @@ Argument N number of untabs to perform"
 Returns (recipe-name body-start body-end) or nil if not in a recipe."
   (save-excursion
     (let ((start-pos (point))
+          (task-regexp "^@?\\([A-Z_a-z][0-9A-Z_a-z-]*\\).*:[^=]")
           task-name body-start body-end)
 
       ;; Find the task we're currently in using the same regex as imenu
       ;; Go back to find a task line
       (while (and (not (bobp))
-                  (not (looking-at "^@?\\([A-Z_a-z][0-9A-Z_a-z-]*\\).*:[^=]")))
+                  (not (looking-at task-regexp)))
         (forward-line -1))
 
-      ;; If we found a task line
-      (when (looking-at "^@?\\([A-Z_a-z][0-9A-Z_a-z-]*\\).*:[^=]")
+      ;; Task line found
+      (when (looking-at task-regexp)
         (setq task-name (match-string 1))
         (setq body-start (line-beginning-position 2))
 
         ;; Find the end of this task by looking for the next task
         (forward-line 1)
         (while (and (not (eobp))
-                    (not (looking-at "^@?\\([A-Z_a-z][0-9A-Z_a-z-]*\\).*:[^=]")))
+                    (not (looking-at task-regexp)))
           (forward-line 1))
 
         ;; Go back to find the last non-empty line before the next task
@@ -336,7 +337,7 @@ Returns (recipe-name body-start body-end) or nil if not in a recipe."
        (if (string-match-p "^\\s-*$" line)
            line
          (if (and (>= (length line) indentation)
-                  (string-match-p (concat "^ \\{" (number-to-string indentation) "\\}") line))
+                  (string-prefix-p (make-string indentation ?\s) line))
              (substring line indentation)
            line)))
      lines


### PR DESCRIPTION
(requested in #8)

Default binding `C-c '` is also like what `org-edit-src-code` uses